### PR TITLE
chore: git-wt の worktree 作成先を改善

### DIFF
--- a/nix/home-manager/git.nix
+++ b/nix/home-manager/git.nix
@@ -46,8 +46,8 @@
       };
       diff.colorMoved = "default";
       wt = {
-        # git-wt resolves relative basedir from the repository root, not the current subdirectory.
-        basedir = "../{gitroot}-worktrees";
+        # Keep git-wt worktrees under each repository.
+        basedir = ".worktrees";
         nocd = "create";
       };
       ghq.root = "${config.home.homeDirectory}/src";
@@ -61,6 +61,9 @@
       };
     };
 
-    ignores = [ ".DS_Store" ];
+    ignores = [
+      ".DS_Store"
+      ".worktrees/"
+    ];
   };
 }


### PR DESCRIPTION
## 概要

- git-wt のデフォルト worktree 作成先を、各リポジトリ直下の .worktrees に変更します。
- .worktrees/ を global Git ignore に追加します。

## 背景

これまでの ../{gitroot}-worktrees は、リポジトリの外側に sibling directory を作る設定でした。
作成先をリポジトリ内に閉じることで、場所が分かりやすくなり、親ディレクトリへの書き込み権限にも依存しにくくなります。

## 確認

- git diff --check
- nix eval .#darwinConfigurations.mami0tsu.config.home-manager.users.mami0tsu.programs.git.settings.wt.basedir
- nix eval .#darwinConfigurations.mami0tsu.config.home-manager.users.mami0tsu.programs.git.ignores