### PR TITLE
Renovate で Nix 更新を自動化する

### DIFF
--- a/.github/workflows/renovate-config-validate.yaml
+++ b/.github/workflows/renovate-config-validate.yaml
@@ -1,0 +1,43 @@
+---
+name: Renovate Config Validate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/renovate-config-validate.yaml
+      - renovate.json
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/renovate-config-validate.yaml
+      - renovate.json
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Validate Renovate Config
+        run: nix shell nixpkgs#renovate -c renovate-config-validator renovate.json

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,54 @@
+---
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 毎週月曜日 09:00 JST に実行する
+    - cron: '0 0 * * 1'
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Run Renovate
+        run: 'nix shell nixpkgs#renovate nixpkgs#go-task -c renovate'
+        env:
+          LOG_LEVEL: info
+          RENOVATE_ALLOWED_COMMANDS: '["^task renovate:update-nix-hashes$"]'
+          RENOVATE_ONBOARDING: 'false'
+          RENOVATE_PLATFORM: github
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_REQUIRE_CONFIG: required
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,18 @@
     }@inputs:
     let
       system = "aarch64-darwin";
+      pkgs = import nixpkgs { inherit system; };
+
+      localPackages = {
+        apm = pkgs.callPackage ./nix/packages/apm.nix { };
+        ax = pkgs.callPackage ./nix/packages/ax.nix { };
+        codex = pkgs.callPackage ./nix/packages/codex.nix { };
+        difit = pkgs.callPackage ./nix/packages/difit.nix { };
+        git-open-src = pkgs.callPackage ./nix/packages/git-open-src.nix { };
+        git-wt = pkgs.callPackage ./nix/packages/git-wt.nix { };
+        roots = pkgs.callPackage ./nix/packages/roots.nix { };
+        zsh-defer-src = pkgs.callPackage ./nix/packages/zsh-defer-src.nix { };
+      };
 
       getDarwinConfig =
         username: useremail:
@@ -63,5 +75,6 @@
     {
       darwinConfigurations.ci = getDarwinConfig "ci" "mami0tsu.jp+ci@gmail.com";
       darwinConfigurations.mami0tsu = getDarwinConfig "mami0tsu" "mami0tsu.jp@gmail.com";
+      packages.${system} = localPackages;
     };
 }

--- a/nix/home-manager/packages-go.nix
+++ b/nix/home-manager/packages-go.nix
@@ -1,55 +1,13 @@
-{ pkgs, ... }:
+{ pkgs, self, ... }:
 
 let
-  roots = pkgs.buildGoModule rec {
-    pname = "roots";
-    version = "0.4.1";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "k1LoW";
-      repo = "roots";
-      rev = "0fa24290d16582550c7156d92a6a040ef79f617d"; # v0.4.1
-      sha256 = "14m4xsazlbb6mrczqn66468y0njb6bjqd5gj1cvig5izcryi28q0";
-    };
-
-    vendorHash = "sha256-uxcT5VzlTCxxnx09p13mot0wVbbas/otoHdg7QSDt4E=";
-
-    nativeCheckInputs = [ pkgs.git ];
-
-    meta = with pkgs.lib; {
-      description = "A CLI tool for managing project roots";
-      homepage = "https://github.com/k1LoW/roots";
-      license = licenses.mit;
-    };
-  };
-
-  git-wt = pkgs.buildGoModule rec {
-    pname = "git-wt";
-    version = "0.27.0";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "k1LoW";
-      repo = "git-wt";
-      rev = "93bab0c27d305f7bfbfa218a4118077d3d77786d"; # v0.27.0
-      sha256 = "0b0fnwbary83jw482325nliv25m0dajjazys3d41kzlgraw3srm0";
-    };
-
-    vendorHash = "sha256-4ak2Gx/i/yvj/tAoDJjsfpBUKJI5iDyKIuv7R7Pzz/w=";
-
-    nativeCheckInputs = [ pkgs.git ];
-
-    meta = with pkgs.lib; {
-      description = "A CLI tool for managing git worktrees";
-      homepage = "https://github.com/k1LoW/git-wt";
-      license = licenses.mit;
-    };
-  };
+  localPackages = self.packages.${pkgs.system};
 in
 {
   home.packages = [
     # vim-goimports が呼ぶ goimports 本体を供給する
     pkgs.gotools
-    roots
-    git-wt
+    localPackages.roots
+    localPackages.git-wt
   ];
 }

--- a/nix/home-manager/packages.nix
+++ b/nix/home-manager/packages.nix
@@ -1,7 +1,11 @@
 {
   pkgs,
+  self,
   ...
 }:
+let
+  localPackages = self.packages.${pkgs.system};
+in
 {
   home.packages = with pkgs; [
     bat # v0.26.1
@@ -18,11 +22,11 @@
     ripgrep # v15.1.0
 
     awscli2 # v2.34.24
-    (pkgs.callPackage ../packages/apm.nix { }) # v0.20.0
-    (pkgs.callPackage ../packages/ax.nix { }) # v0.1.10
+    localPackages.apm # v0.20.0
+    localPackages.ax # v0.1.10
     claude-code # v2.1.161
-    (pkgs.callPackage ../packages/codex.nix { }) # v0.142.3
-    (pkgs.callPackage ../packages/difit.nix { }) # v4.0.5
+    localPackages.codex # v0.142.3
+    localPackages.difit # v4.0.5
     docker_29 # v29.5.2
     fzf # v0.73.1
     gh # v2.93.0

--- a/nix/home-manager/zsh.nix
+++ b/nix/home-manager/zsh.nix
@@ -1,8 +1,12 @@
 {
   config,
   pkgs,
+  self,
   ...
 }:
+let
+  localPackages = self.packages.${pkgs.system};
+in
 {
   programs.zsh = {
     enable = true;
@@ -74,12 +78,7 @@
     plugins = [
       {
         name = "zsh-defer";
-        src = pkgs.fetchFromGitHub {
-          owner = "romkatv";
-          repo = "zsh-defer";
-          rev = "53a26e287fbbe2dcebb3aa1801546c6de32416fa";
-          sha256 = "sha256-MFlvAnPCknSgkW3RFA8pfxMZZS/JbyF3aMsJj9uHHVU=";
-        };
+        src = localPackages.zsh-defer-src;
       }
       {
         name = "zsh-autosuggestions";
@@ -95,12 +94,7 @@
       }
       {
         name = "git-open";
-        src = pkgs.fetchFromGitHub {
-          owner = "paulirish";
-          repo = "git-open";
-          rev = "63c0e77aaf18b72c839b1113c1e2f9514413643b";
-          sha256 = "sha256-E93A/KBEGlPDm98p1ClvWxzjK2ylv3BrVaEvBcuD6c4=";
-        };
+        src = localPackages.git-open-src;
       }
     ];
   };

--- a/nix/packages/apm.nix
+++ b/nix/packages/apm.nix
@@ -6,6 +6,7 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "apm";
+  # renovate: datasource=github-releases depName=microsoft/apm extractVersion=^v(?<version>.+)$
   version = "0.20.0";
   assetName = "apm-darwin-arm64";
   archiveName = "${assetName}.tar.gz";

--- a/nix/packages/ax.nix
+++ b/nix/packages/ax.nix
@@ -6,6 +6,7 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "ax";
+  # renovate: datasource=github-releases depName=yusukebe/ax extractVersion=^v(?<version>.+)$
   version = "0.1.10";
   assetName = "ax-darwin-arm64";
 

--- a/nix/packages/codex.nix
+++ b/nix/packages/codex.nix
@@ -6,6 +6,7 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "codex";
+  # renovate: datasource=github-releases depName=openai/codex extractVersion=^rust-v(?<version>.+)$
   version = "0.142.3";
   assetName = "codex-aarch64-apple-darwin";
   archiveName = "${assetName}.tar.gz";

--- a/nix/packages/difit.nix
+++ b/nix/packages/difit.nix
@@ -11,6 +11,7 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "difit";
+  # renovate: datasource=github-releases depName=yoshiko-pg/difit extractVersion=^v(?<version>.+)$
   version = "4.0.5";
 
   src = fetchFromGitHub {

--- a/nix/packages/git-open-src.nix
+++ b/nix/packages/git-open-src.nix
@@ -1,0 +1,28 @@
+{
+  fetchFromGitHub,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "git-open-src";
+  version = "unstable";
+
+  src = fetchFromGitHub {
+    owner = "paulirish";
+    repo = "git-open";
+    # renovate: datasource=git-refs packageName=https://github.com/paulirish/git-open currentValue=master
+    rev = "63c0e77aaf18b72c839b1113c1e2f9514413643b";
+    hash = "sha256-E93A/KBEGlPDm98p1ClvWxzjK2ylv3BrVaEvBcuD6c4=";
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -R "$src" "$out"
+
+    runHook postInstall
+  '';
+}

--- a/nix/packages/git-wt.nix
+++ b/nix/packages/git-wt.nix
@@ -1,0 +1,29 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+  lib,
+}:
+
+buildGoModule rec {
+  pname = "git-wt";
+  # renovate: datasource=github-tags depName=k1LoW/git-wt extractVersion=^v(?<version>.+)$
+  version = "0.27.0";
+
+  src = fetchFromGitHub {
+    owner = "k1LoW";
+    repo = "git-wt";
+    tag = "v${version}";
+    hash = "sha256-oGY9uMqP/hlIG9p/JaVqoBaxI7VFDIEIlwP5rBa3Diw=";
+  };
+
+  vendorHash = "sha256-4ak2Gx/i/yvj/tAoDJjsfpBUKJI5iDyKIuv7R7Pzz/w=";
+
+  nativeCheckInputs = [ git ];
+
+  meta = {
+    description = "A CLI tool for managing git worktrees";
+    homepage = "https://github.com/k1LoW/git-wt";
+    license = lib.licenses.mit;
+  };
+}

--- a/nix/packages/roots.nix
+++ b/nix/packages/roots.nix
@@ -1,0 +1,29 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+  lib,
+}:
+
+buildGoModule rec {
+  pname = "roots";
+  # renovate: datasource=github-tags depName=k1LoW/roots extractVersion=^v(?<version>.+)$
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "k1LoW";
+    repo = "roots";
+    tag = "v${version}";
+    hash = "sha256-ACMRfWY/lhc3C/KVhuUyS1rgkSHGWPxZrmYt+pXupJI=";
+  };
+
+  vendorHash = "sha256-uxcT5VzlTCxxnx09p13mot0wVbbas/otoHdg7QSDt4E=";
+
+  nativeCheckInputs = [ git ];
+
+  meta = {
+    description = "A CLI tool for managing project roots";
+    homepage = "https://github.com/k1LoW/roots";
+    license = lib.licenses.mit;
+  };
+}

--- a/nix/packages/zsh-defer-src.nix
+++ b/nix/packages/zsh-defer-src.nix
@@ -1,0 +1,28 @@
+{
+  fetchFromGitHub,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "zsh-defer-src";
+  version = "unstable";
+
+  src = fetchFromGitHub {
+    owner = "romkatv";
+    repo = "zsh-defer";
+    # renovate: datasource=git-refs packageName=https://github.com/romkatv/zsh-defer currentValue=master
+    rev = "53a26e287fbbe2dcebb3aa1801546c6de32416fa";
+    hash = "sha256-MFlvAnPCknSgkW3RFA8pfxMZZS/JbyF3aMsJj9uHHVU=";
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -R "$src" "$out"
+
+    runHook postInstall
+  '';
+}

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
   "schedule": [
     "before 6am on monday"
   ],
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "internalChecksFilter": "strict",
   "enabledManagers": [
     "custom.regex",
     "github-actions",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "Asia/Tokyo",
+  "schedule": [
+    "before 6am on monday"
+  ],
+  "enabledManagers": [
+    "custom.regex",
+    "github-actions",
+    "nix"
+  ],
+  "nix": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 6am on monday"
+    ]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update local Nix package versions.",
+      "managerFilePatterns": [
+        "/^nix/packages/.*\\.nix$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) extractVersion=(?<extractVersion>\\S+)\\s+version = \"(?<currentValue>[^\"]+)\";"
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinned Git refs for local Nix sources.",
+      "managerFilePatterns": [
+        "/^nix/packages/.*-src\\.nix$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=git-refs packageName=(?<packageName>\\S+) currentValue=(?<currentValue>\\S+)\\s+rev = \"(?<currentDigest>[a-f0-9]{40})\";"
+      ],
+      "depNameTemplate": "{{{packageName}}}",
+      "datasourceTemplate": "git-refs"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "nix"
+      ],
+      "groupName": "nix flake inputs",
+      "commitMessageTopic": "nix flake inputs"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions",
+      "commitMessageTopic": "github actions"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "groupName": "local nix packages",
+      "commitMessageTopic": "local nix packages",
+      "postUpgradeTasks": {
+        "commands": [
+          "task renovate:update-nix-hashes"
+        ],
+        "fileFilters": [
+          "flake.nix",
+          "nix/**/*.nix"
+        ],
+        "executionMode": "branch"
+      }
+    }
+  ]
+}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -4,6 +4,7 @@ includes:
   agent-plugins: ./taskfiles/agent-plugins.yaml
   agent-skills: ./taskfiles/agent-skills.yaml
   nix: ./taskfiles/nix.yaml
+  renovate: ./taskfiles/renovate.yaml
 
 env:
   REPO_ROOT: '{{.ROOT_DIR}}'

--- a/taskfiles/renovate.yaml
+++ b/taskfiles/renovate.yaml
@@ -1,0 +1,27 @@
+version: '3'
+
+tasks:
+  update-nix-hashes:
+    desc: Update fixed-output hashes for local Nix packages after Renovate changes.
+    cmds:
+      - |
+        packages=(
+          apm
+          ax
+          codex
+          difit
+          roots
+          git-wt
+          zsh-defer-src
+          git-open-src
+        )
+
+        for package in "${packages[@]}"; do
+          nix run nixpkgs#nix-update -- \
+            --flake \
+            --system aarch64-darwin \
+            --version=skip \
+            "$package"
+        done
+
+        nix flake check --no-build --no-update-lock-file


### PR DESCRIPTION
## 変更内容

Renovate を GitHub Actions 上で実行する workflow を追加しました。

`flake.lock`、GitHub Actions、手書きの Nix package を Renovate の更新対象にしました。

手書きの Nix package は `# renovate:` コメントで更新元を明示し、更新後の fixed-output hash は `task renovate:update-nix-hashes` で再計算します。

## 背景

Nix で管理している依存には、flake input だけでなく、GitHub Releases、GitHub tag、Git ref、Go module の vendor hash が混在しています。

Dependabot だけではこの範囲をまとめて扱いにくいため、Renovate に寄せて更新入口を一本化しました。

## 検証

- `jq empty renovate.json`
- YAML parse
- `renovate-config-validator renovate.json`
- `renovate --platform=local --dry-run=lookup`
- `task renovate:update-nix-hashes`
- `nix flake check --no-build --no-update-lock-file`
- `nix build --no-link --print-build-logs .#darwinConfigurations.ci.system`

## 補足

Renovate workflow の実行には `RENOVATE_APP_ID` と `RENOVATE_APP_PRIVATE_KEY` が必要です。
