### PR TITLE
Renovate の schedule を一時的に常時許可する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "timezone": "Asia/Tokyo",
   "schedule": [
-    "before 6am on monday"
+    "at any time"
   ],
   "minimumReleaseAge": "7 days",
   "minimumReleaseAgeBehaviour": "timestamp-required",
@@ -21,7 +21,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
-      "before 6am on monday"
+      "at any time"
     ]
   },
   "customManagers": [


### PR DESCRIPTION
## 変更内容

Renovate の実行可能時間を一時的に広げました。

- トップレベルの `schedule` を `at any time` に変更
- `lockFileMaintenance.schedule` も `at any time` に変更

## 背景

現在は GitHub Actions の手動実行で Renovate の挙動を確認したい段階です。
Renovate 側の schedule が `before 6am on monday` のままだと、手動実行しても PR 作成や lock file maintenance が schedule 外として抑止されます。

## 確認

- `jq empty renovate.json`
- `git diff --check`
