### PR TITLE
Allow Renovate to write commit statuses

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -34,6 +34,7 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-statuses: write
           permission-workflows: write
 
       - name: Checkout


### PR DESCRIPTION
## 概要

Renovate の GitHub App token に commit status の書き込み権限を追加します。

## 変更内容

- Renovate workflow の `actions/create-github-app-token` に `permission-statuses: write` を追加しました。

## レビュー観点

- Renovate が更新ブランチ作成後に commit status を設定できるようになることを確認してください。
- `contents`、`issues`、`pull-requests`、`workflows` の既存権限には変更を加えていません。

## 参考情報

- https://github.com/mami0tsu/dotfiles/actions/runs/29711765419
