### PR TITLE
nixvim のドキュメント生成警告を解消

### DIFF
--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -9,6 +9,8 @@
   # Home Manager の互換性を保つための状態バージョンを指定する
   home.stateVersion = "25.11";
 
+  manual.manpages.enable = false;
+
   programs.home-manager.enable = true;
 
   imports = [

--- a/nix/home-manager/nixvim.nix
+++ b/nix/home-manager/nixvim.nix
@@ -10,7 +10,8 @@
 
   programs.nixvim = {
     enable = true;
-    nixpkgs.source = inputs.nixpkgs.outPath;
+    enableMan = false;
+    nixpkgs.source = inputs.nixpkgs;
 
     extraConfigLua = builtins.readFile ../../nvim/init.lua;
 

--- a/nix/home-manager/packages-go.nix
+++ b/nix/home-manager/packages-go.nix
@@ -1,7 +1,7 @@
 { pkgs, self, ... }:
 
 let
-  localPackages = self.packages.${pkgs.system};
+  localPackages = self.packages.${pkgs.stdenv.hostPlatform.system};
 in
 {
   home.packages = [

--- a/nix/home-manager/packages.nix
+++ b/nix/home-manager/packages.nix
@@ -4,7 +4,7 @@
   ...
 }:
 let
-  localPackages = self.packages.${pkgs.system};
+  localPackages = self.packages.${pkgs.stdenv.hostPlatform.system};
 in
 {
   home.packages = with pkgs; [

--- a/nix/home-manager/zsh.nix
+++ b/nix/home-manager/zsh.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  localPackages = self.packages.${pkgs.system};
+  localPackages = self.packages.${pkgs.stdenv.hostPlatform.system};
 in
 {
   programs.zsh = {


### PR DESCRIPTION
## 概要

- nixvim の manpage 生成を無効化し、pandoc の Lua 非対応による deploy 失敗を回避する。
- Home Manager の manpage 生成を無効化し、options.json の store path context 警告を回避する。
- 非推奨の pkgs.system 参照を pkgs.stdenv.hostPlatform.system に置き換える。
- nixvim に渡す nixpkgs source を .outPath ではなく flake input そのものにする。

## 確認

- nix build --dry-run .#darwinConfigurations.mami0tsu.system
- nix build .#darwinConfigurations.mami0tsu.system