### PR TITLE
GitHub MCP token の起動前確認を明記する P-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ plugin install/update に寄せます。Home Manager は MCP 設定ファイル�
 
 GitHub MCP は `gh` で取得できない読み取り専用の文脈を補う fallback として使います。
 `GITHUB_MCP_TOKEN` に最小権限の PAT を設定します。秘密値は dotfiles では管理しません。
+Codex を起動するシェルで `printenv GITHUB_MCP_TOKEN` が値を返すことを確認してから使います。
+値が空の場合、GitHub MCP は起動時に token 未設定エラーで停止します。
 
 ## 管理内容
 

--- a/agent-plugin-marketplace/plugins/development/README.md
+++ b/agent-plugin-marketplace/plugins/development/README.md
@@ -16,6 +16,8 @@ Codex CLI と Claude Code で共通利用する開発用 plugin です。
 
 GitHub MCP server を使う前に、`GITHUB_MCP_TOKEN` に最小権限の GitHub PAT を設定します。
 GitHub MCP server は、`gh` で必要な読み取り専用の文脈を取得できない場合の fallback として使います。
+Codex または Claude Code を起動するシェルで `printenv GITHUB_MCP_TOKEN` が値を返すことを確認してから使います。
+値が空の場合、GitHub MCP server は起動時に token 未設定エラーで停止します。
 
 ## Required External Skills
 


### PR DESCRIPTION
## 概要

GitHub MCP server が `GITHUB_MCP_TOKEN` 未設定で起動失敗するため、Codex または Claude Code を起動する前に環境変数を確認する手順を README に追記します。

## 変更内容

- `README.md` に `printenv GITHUB_MCP_TOKEN` による確認手順を追加
- development plugin README に同じ確認手順を追加
- 秘密値を dotfiles で管理しない方針は維持

## 検証

- documentation-only change

Linear: P-14