### PR TITLE
Terraform MCP の Docker daemon 前提を明記する P-15

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ plugin install/update に寄せます。Home Manager は MCP 設定ファイル�
 
 GitHub MCP は `gh` で取得できない読み取り専用の文脈を補う fallback として使います。
 `GITHUB_MCP_TOKEN` に最小権限の PAT を設定します。秘密値は dotfiles では管理しません。
+Terraform MCP は Docker daemon が起動している環境で使います。
+Docker daemon が停止している場合、Codex の起動時に initialize 前後で接続が閉じます。
 
 ## 管理内容
 

--- a/agent-plugin-marketplace/plugins/development/README.md
+++ b/agent-plugin-marketplace/plugins/development/README.md
@@ -16,6 +16,8 @@ Codex CLI と Claude Code で共通利用する開発用 plugin です。
 
 GitHub MCP server を使う前に、`GITHUB_MCP_TOKEN` に最小権限の GitHub PAT を設定します。
 GitHub MCP server は、`gh` で必要な読み取り専用の文脈を取得できない場合の fallback として使います。
+Terraform MCP server は Docker daemon が起動している環境で使います。
+Docker daemon が停止している場合、Codex の起動時に initialize 前後で接続が閉じます。
 
 ## Required External Skills
 


### PR DESCRIPTION
## 概要

Terraform MCP server は Docker 経由で起動するため、Docker daemon が停止していると initialize 前後で接続が閉じます。
この前提を README に明記します。

## 変更内容

- `README.md` に Docker daemon 起動前提を追記
- development plugin README に Docker daemon 起動前提を追記

## 検証

- `docker run -i --rm hashicorp/terraform-mcp-server:1.1.0 --toolsets=registry` に raw JSON-RPC `initialize` を送信し、正常な initialize result を確認

Linear: P-15