### PR TITLE
Codex 用 AWS MCP に AWS_REGION metadata を渡す P-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,15 @@ plugin install/update に寄せます。Home Manager は MCP 設定ファイル�
 - Claude Code marketplace: `agent-plugin-marketplace/.claude-plugin/marketplace.json`
 - Plugin packages: `agent-plugin-marketplace/plugins/development`, `agent-plugin-marketplace/plugins/documentation`
 
-初期 MCP server は次の通りです。
+Codex の初期 MCP server は次の通りです。
 
-- AWS MCP: `uvx mcp-proxy-for-aws==1.6.3 https://aws-mcp.us-east-1.api.aws/mcp --region ap-northeast-1`
+- AWS MCP: `uvx mcp-proxy-for-aws==1.6.3 https://aws-mcp.us-east-1.api.aws/mcp --metadata AWS_REGION=ap-northeast-1`
 - Terraform MCP: `docker run -i --rm hashicorp/terraform-mcp-server:1.1.0 --toolsets=registry`
 - GitHub MCP: `https://api.githubcopilot.com/mcp/`
 
 GitHub MCP は `gh` で取得できない読み取り専用の文脈を補う fallback として使います。
 `GITHUB_MCP_TOKEN` に最小権限の PAT を設定します。秘密値は dotfiles では管理しません。
+Claude Code 用 `.mcp.json` では、AWS MCP に `--region ap-northeast-1` を渡します。
 
 ## 管理内容
 

--- a/agent-plugin-marketplace/plugins/development/.codex-plugin/plugin.json
+++ b/agent-plugin-marketplace/plugins/development/.codex-plugin/plugin.json
@@ -26,8 +26,8 @@
       "args": [
         "mcp-proxy-for-aws==1.6.3",
         "https://aws-mcp.us-east-1.api.aws/mcp",
-        "--region",
-        "ap-northeast-1"
+        "--metadata",
+        "AWS_REGION=ap-northeast-1"
       ]
     },
     "terraform": {

--- a/agent-plugin-marketplace/plugins/development/README.md
+++ b/agent-plugin-marketplace/plugins/development/README.md
@@ -10,7 +10,8 @@ Codex CLI と Claude Code で共通利用する開発用 plugin です。
 
 ## MCP Server
 
-- `aws`: `uvx mcp-proxy-for-aws==1.6.3 https://aws-mcp.us-east-1.api.aws/mcp --region ap-northeast-1`
+- `aws`: Codex では `uvx mcp-proxy-for-aws==1.6.3 https://aws-mcp.us-east-1.api.aws/mcp --metadata AWS_REGION=ap-northeast-1`
+- `aws`: Claude Code では `uvx mcp-proxy-for-aws==1.6.3 https://aws-mcp.us-east-1.api.aws/mcp --region ap-northeast-1`
 - `terraform`: `docker run -i --rm hashicorp/terraform-mcp-server:1.1.0 --toolsets=registry`
 - `github`: リモート GitHub MCP server `https://api.githubcopilot.com/mcp/`
 


### PR DESCRIPTION
## 概要

Codex plugin の AWS MCP proxy 起動引数を、AWS 操作用リージョンを metadata として渡す形に変更します。
Claude Code 用 `.mcp.json` は `--region ap-northeast-1` を維持します。

## 変更内容

- Codex plugin の AWS MCP 引数を `--metadata AWS_REGION=ap-northeast-1` に変更
- README に Codex 用と Claude Code 用の AWS MCP 引数の違いを明記
- development plugin README に同じ差分を追記

## 検証

- `jq empty agent-plugin-marketplace/plugins/development/.codex-plugin/plugin.json`
- Codex style: `uvx mcp-proxy-for-aws==1.6.3 ... --metadata AWS_REGION=ap-northeast-1 --skip-auth` に raw JSON-RPC `initialize` を送信し、正常な initialize result を確認
- Claude style: `uvx mcp-proxy-for-aws==1.6.3 ... --region ap-northeast-1 --skip-auth` に raw JSON-RPC `initialize` を送信し、正常な initialize result を確認

Linear: P-16