### PR TITLE
agent-plugins:migrate で旧 dotfiles 登録を正確に削除する P-18

### DIFF
--- a/taskfiles/agent-plugins.yaml
+++ b/taskfiles/agent-plugins.yaml
@@ -5,7 +5,8 @@ vars:
   agent_plugin_legacy_marketplace_name: dotfiles
   development_plugin_ref: 'development@{{.agent_plugin_marketplace_name}}'
   documentation_plugin_ref: 'documentation@{{.agent_plugin_marketplace_name}}'
-  agent_plugin_legacy_ref: 'development@{{.agent_plugin_legacy_marketplace_name}}'
+  development_plugin_legacy_ref: 'development@{{.agent_plugin_legacy_marketplace_name}}'
+  documentation_plugin_legacy_ref: 'documentation@{{.agent_plugin_legacy_marketplace_name}}'
   agent_plugin_marketplace_dir: '{{.REPO_ROOT}}/agent-plugin-marketplace'
   development_plugin_dir: '{{.agent_plugin_marketplace_dir}}/plugins/development'
   documentation_plugin_dir: '{{.agent_plugin_marketplace_dir}}/plugins/documentation'
@@ -83,7 +84,10 @@ tasks:
     cmds:
       - task: claude:uninstall-plugin-if-installed
         vars:
-          PLUGIN_REF: '{{.agent_plugin_legacy_ref}}'
+          PLUGIN_REF: '{{.development_plugin_legacy_ref}}'
+      - task: claude:uninstall-plugin-if-installed
+        vars:
+          PLUGIN_REF: '{{.documentation_plugin_legacy_ref}}'
       - task: claude:remove-marketplace-if-configured
         vars:
           MARKETPLACE_NAME: '{{.agent_plugin_legacy_marketplace_name}}'
@@ -129,7 +133,10 @@ tasks:
     cmds:
       - task: codex:remove-plugin-if-installed
         vars:
-          PLUGIN_REF: '{{.agent_plugin_legacy_ref}}'
+          PLUGIN_REF: '{{.development_plugin_legacy_ref}}'
+      - task: codex:remove-plugin-if-installed
+        vars:
+          PLUGIN_REF: '{{.documentation_plugin_legacy_ref}}'
       - task: codex:remove-marketplace-if-configured
         vars:
           MARKETPLACE_NAME: '{{.agent_plugin_legacy_marketplace_name}}'


### PR DESCRIPTION
## 概要

- `agent-plugins:migrate` で `development@dotfiles` と `documentation@dotfiles` の両方を削除するようにした。
- Codex CLI と Claude Code の両方で、旧 marketplace `dotfiles` の削除を冪等にした。

## 検証

- 一時 HOME に旧 `dotfiles` marketplace を作成
- `development@dotfiles` と `documentation@dotfiles` を Codex CLI と Claude Code にインストール
- `task agent-plugins:migrate` を2回連続実行
- Codex CLI と Claude Code の plugin / marketplace list から旧登録が消えたことを確認

Linear: https://linear.app/mami0tsu/issue/P-18/agent-pluginsmigrate-で旧-dotfiles-登録を正確に削除する
