### PR TITLE
Taskfile の冪等性検証と README 更新を行う P-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ task agent-skills:install
 task deploy
 ```
 
+`task deploy` は再実行できます。
+既に登録済みの agent plugin や skill link がある場合は、必要な差分だけを反映します。
+
 target を明示する場合は `TARGET` に指定します。
 
 ```sh
@@ -75,6 +78,9 @@ TARGET=mami0tsu task deploy
 ```sh
 task clean
 ```
+
+`task clean` も再実行できます。
+未登録の agent plugin や削除済みの APM 生成物は、削除済みとして扱います。
 
 ## Agent Skills
 
@@ -88,6 +94,10 @@ Agent Skills は、自作 skill と外部由来 skill で管理方法を分け�
 ```sh
 task agent-skills:refresh
 ```
+
+APM 管理から外れた skill の symlink は、`task agent-skills:clean` または `task agent-skills:deploy` で削除します。
+通常ディレクトリや、dotfiles の `.agents/skills` 以外を指す symlink は削除しません。
+`task agent-skills:clean` は APM の生成物として `.agents/skills` と `apm_modules/` も削除します。
 
 `.agents/` と `apm_modules/` は生成物なので Git 管理しません。
 
@@ -111,6 +121,12 @@ plugin install/update に寄せます。Home Manager は MCP 設定ファイル�
 
 GitHub MCP は `gh` で取得できない読み取り専用の文脈を補う fallback として使います。
 `GITHUB_MCP_TOKEN` に最小権限の PAT を設定します。秘密値は dotfiles では管理しません。
+
+旧 marketplace name `dotfiles` から移行した環境では、次の task で古い登録を削除します。
+
+```sh
+task agent-plugins:migrate
+```
 
 ## 管理内容
 

--- a/agent-plugin-marketplace/README.md
+++ b/agent-plugin-marketplace/README.md
@@ -23,6 +23,13 @@ codex plugin add development@mami0tsu
 codex plugin add documentation@mami0tsu
 ```
 
+通常は次の task で登録します。
+既に登録済みの場合も再実行できます。
+
+```sh
+task agent-plugins:deploy
+```
+
 ## Claude Code
 
 ```sh
@@ -31,9 +38,18 @@ claude plugin install development@mami0tsu
 claude plugin install documentation@mami0tsu
 ```
 
+登録を削除するときは次の task を使います。
+未登録の状態でも再実行できます。
+
+```sh
+task agent-plugins:clean
+```
+
 ## 旧 marketplace からの移行
 
 旧 marketplace name `dotfiles` の登録を削除するときは、次の task を使います。
+`development@dotfiles` と `documentation@dotfiles` を削除してから、旧 marketplace を削除します。
+旧登録がない状態でも再実行できます。
 
 ```sh
 task agent-plugins:migrate


### PR DESCRIPTION
## 概要

- deploy / clean task が再実行できることを README に追記した。
- APM skill の stale symlink 掃除の挙動を README に追記した。
- 旧 `dotfiles` marketplace からの移行 task の挙動を README に追記した。

## 検証

- 日本語 README 更新を repository の writing rule に沿って確認
- `git diff --check HEAD~4..HEAD`

Linear: https://linear.app/mami0tsu/issue/P-20/taskfile-の冪等性検証と-readme-更新を行う
