### PR TITLE
agent-skills の stale symlink を安全に掃除する P-19

### DIFF
--- a/taskfiles/agent-skills.yaml
+++ b/taskfiles/agent-skills.yaml
@@ -5,23 +5,31 @@ vars:
     - $HOME/.codex/skills
     - $HOME/.claude/skills
   apm_skills_dir: '{{.APM_SKILLS_DIR | default ".agents/skills"}}'
+  apm_modules_dir: '{{.APM_MODULES_DIR | default "apm_modules"}}'
   apm_skills_install_args: --target agent-skills --only apm
 
 tasks:
   clean:
-    desc: Unlink APM-managed skills and remove their materialized files.
+    desc: Unlink APM-managed skills and remove generated APM files.
     cmds:
       - task: unlink
       - |
         apm_skills_dir="{{.REPO_ROOT}}/{{.apm_skills_dir}}"
+        apm_modules_dir="{{.REPO_ROOT}}/{{.apm_modules_dir}}"
 
         if [[ -d "$apm_skills_dir" ]]; then
           rm -r "$apm_skills_dir"
         fi
 
+        if [[ -d "$apm_modules_dir" ]]; then
+          rm -r "$apm_modules_dir"
+        fi
+      - task: prune-stale-links
+
   deploy:
     desc: Materialize locked APM skills and link them into agent skill directories.
     cmds:
+      - task: clean
       - apm install {{.apm_skills_install_args}} --frozen
       - task: link
 
@@ -97,4 +105,43 @@ tasks:
           if [[ -L "$agent_skill_dir" && "$(readlink "$agent_skill_dir")" == "$apm_skill_dir" ]]; then
             unlink "$agent_skill_dir"
           fi
+        done
+
+  prune-stale-links:
+    internal: true
+    silent: true
+    cmds:
+      - for: { var: agent_skills_dirs, as: AGENT_SKILLS_DIR }
+        task: prune-stale-links-from-agent-skills-dir
+        vars:
+          AGENT_SKILLS_DIR: '{{.AGENT_SKILLS_DIR}}'
+
+  prune-stale-links-from-agent-skills-dir:
+    internal: true
+    silent: true
+    cmds:
+      - |
+        apm_skills_dir="{{.REPO_ROOT}}/{{.apm_skills_dir}}"
+        agent_skills_dir="{{.AGENT_SKILLS_DIR}}"
+
+        if [[ ! -d "$agent_skills_dir" ]]; then
+          exit 0
+        fi
+
+        shopt -s nullglob
+
+        for agent_skill_dir in "$agent_skills_dir"/*; do
+          if [[ ! -L "$agent_skill_dir" ]]; then
+            continue
+          fi
+
+          skill_target="$(readlink "$agent_skill_dir")"
+
+          case "$skill_target" in
+            "$apm_skills_dir"/*)
+              if [[ ! -e "$skill_target" ]]; then
+                unlink "$agent_skill_dir"
+              fi
+              ;;
+          esac
         done


### PR DESCRIPTION
## 概要

- repo 管理下の `.agents/skills` を指す stale symlink を削除するようにした。
- 通常ディレクトリと、repo 管理外を指す symlink は削除しないようにした。
- `agent-skills:clean` で `apm_modules/` も削除するようにした。
- `agent-skills:deploy` は clean 後に APM install と link を実行するようにした。

## 検証

- 一時 HOME に stale symlink、通常ディレクトリ、管理外 symlink を作成
- `task agent-skills:clean` で stale symlink だけが削除されることを確認
- 承認付きで `task agent-skills:deploy` を2回連続実行

Linear: https://linear.app/mami0tsu/issue/P-19/agent-skills-の-stale-symlink-を安全に掃除する
