### PR TITLE
Nix workflow の重複検証を削減する P-21

### DIFF
--- a/.github/workflows/nix-config-test.yaml
+++ b/.github/workflows/nix-config-test.yaml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Cache Nix
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+        with:
+          use-flakehub: disabled
+          diff-store: true
 
       - name: Build Darwin Configuration
         run: nix build --no-link --no-update-lock-file --print-build-logs .#darwinConfigurations.ci.system

--- a/.github/workflows/nix-config-test.yaml
+++ b/.github/workflows/nix-config-test.yaml
@@ -50,8 +50,5 @@ jobs:
       - name: Cache Nix
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
 
-      - name: Check Nix Flake
-        run: nix flake check --no-build --no-update-lock-file
-
-      - name: Build Nix Package for CI
-        run: nix build --no-link --print-build-logs .#darwinConfigurations.ci.system
+      - name: Build Darwin Configuration
+        run: nix build --no-link --no-update-lock-file --print-build-logs .#darwinConfigurations.ci.system

--- a/.github/workflows/nix-config-test.yaml
+++ b/.github/workflows/nix-config-test.yaml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Cache Nix
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+        with:
+          use-gha-cache: ${{ github.event_name == 'push' && 'enabled' || 'disabled' }}
+          use-flakehub: disabled
 
       - name: Build Darwin Configuration
         run: nix build --no-link --no-update-lock-file --print-build-logs .#darwinConfigurations.ci.system


### PR DESCRIPTION
## 概要

- `.github/workflows/nix-config-test.yaml` の重複した flake 評価 step を削除する。
- `magic-nix-cache-action` は残し、PR では GHA cache upload を無効化する。
- `main` への push では GHA cache upload を有効にし、共有 cache の更新経路は維持する。
- FlakeHub cache upload は使わないため `use-flakehub: disabled` を明示する。
- Darwin configuration の build step に `--no-update-lock-file` を追加し、CI で lockfile が更新されない状態を保つ。

## 判断理由

今回のボトルネックは build ではなく `Post Cache Nix` の upload 側だった。

PR で毎回 GHA cache に大量の Nix store path を upload すると、warm run でも post step が 10 分以上かかる。
一方で cache action 自体を外すと main 側の cache 更新経路まで失うため、依存は削らず、PR と push で upload 方針を分ける。

`flake.nix` には現在 `checks` 出力がないため、独立した `nix flake check --no-build` は主に flake の評価確認として働いている。
後続の `nix build .#darwinConfigurations.ci.system` でも Darwin configuration の評価が行われるため、CI の保証は build step に寄せる。

## 確認

- workflow YAML の読み込み: OK
- `nix build --dry-run --no-link --no-update-lock-file .#darwinConfigurations.ci.system`: OK
- PR #49 初回 run: 18分58秒
- warm run: 13分38秒、`Post Cache Nix` は 10分30秒
- `diff-store: true` 診断 run: 22分53秒、`Post Cache Nix` は 19分10秒
- PR の GHA cache upload 無効化後: 7分54秒、`Post Cache Nix` は 4秒

## 補足

`DeterminateSystems/nix-installer-action` と `DeterminateSystems/magic-nix-cache-action` は、この PR では削除しない。
現時点の実測では、削るべき対象は action そのものではなく、PR 実行時の cache upload だったため。