### PR TITLE
Codex と Claude Code のバージョンを更新する

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,17 +103,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784515365,
-        "narHash": "sha256-Qp8SfqvCYHcZewQ4LgD0263yQuaputMceSquLFeza6I=",
+        "lastModified": 1784812282,
+        "narHash": "sha256-Na4aTmdz22ovtSvcvNKaRwEWkg801hDyX6t8JqvW+sE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "141f212d3652c61515ba4e9478c8093fca278bac",
+        "rev": "6d12004108e0e4a5cfa4bd83b14477f040b15773",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "141f212d3652c61515ba4e9478c8093fca278bac",
+        "rev": "6d12004108e0e4a5cfa4bd83b14477f040b15773",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url =
-      "github:nixos/nixpkgs/141f212d3652c61515ba4e9478c8093fca278bac"; # nixpkgs-unstable
+      "github:nixos/nixpkgs/6d12004108e0e4a5cfa4bd83b14477f040b15773"; # nixpkgs-unstable
     home-manager = {
       url =
         "github:nix-community/home-manager/3139deb8cafbe73b39b24451255b2fdd3426077e"; # master

--- a/nix/home-manager/packages.nix
+++ b/nix/home-manager/packages.nix
@@ -25,8 +25,8 @@ in
     awscli2 # v2.34.24
     localPackages.apm # v0.20.0
     localPackages.ax # v0.1.10
-    claude-code # v2.1.161
-    localPackages.codex # v0.142.3
+    claude-code # v2.1.217
+    localPackages.codex # v0.145.0
     localPackages.difit # v4.0.5
     docker_29 # v29.5.2
     fzf # v0.73.1

--- a/nix/packages/codex.nix
+++ b/nix/packages/codex.nix
@@ -7,13 +7,13 @@
 stdenvNoCC.mkDerivation rec {
   pname = "codex";
   # renovate: datasource=github-releases depName=openai/codex extractVersion=^rust-v(?<version>.+)$
-  version = "0.142.3";
+  version = "0.145.0";
   assetName = "codex-aarch64-apple-darwin";
   archiveName = "${assetName}.tar.gz";
 
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${archiveName}";
-    hash = "sha256-wwMVy0HWbQAPya1mc19CiNn/DH/nSPaPcautcC1y+DI=";
+    hash = "sha256-Byowpl8FZmc1iJ7w9gtW2xhq293p1cXMGmS+C1mFMP4=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
## 概要

- Codex を `0.145.0` に更新した。
- nixpkgs pin を更新し、Claude Code を nixpkgs 上の `2.1.217` に更新した。
- `nix/home-manager/packages.nix` の version コメントを実際の更新後 version に合わせた。

## 補足

- npm registry 上の Claude Code 最新は `2.1.220`。
- 現在の `nixpkgs-unstable` では `claude-code` は `2.1.217` だったため、この PR では nixpkgs 由来の最新まで更新している。

## 検証

- `nix eval --raw .#packages.aarch64-darwin.codex.version`
- `nix eval --raw .#darwinConfigurations.ci.pkgs.claude-code.version`
- `nix build .#packages.aarch64-darwin.codex --no-link`
- build 済み Codex binary の `codex --version`
- `nix flake check --no-build`
- `git diff --check`
- difit review: コメントなし
